### PR TITLE
fix(rpc):[ums-memberservice] fix memberlogin && querrymemberlist bug

### DIFF
--- a/pkg/pointerprocess/processnil.go
+++ b/pkg/pointerprocess/processnil.go
@@ -1,0 +1,18 @@
+package pointerprocess
+
+import "reflect"
+
+func DefaltData(v interface{}) interface{} {
+	// 使用反射检查传入的值是否是一个指针
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		if !val.IsNil() {
+			// 返回指针指向的值
+			return val.Elem().Interface()
+		}
+		// 返回指针类型的零值
+		return reflect.Zero(val.Type().Elem()).Interface()
+	}
+	// 如果不是指针类型，直接返回零值
+	return reflect.Zero(val.Type()).Interface()
+}

--- a/rpc/ums/internal/logic/memberservice/memberloginlogic.go
+++ b/rpc/ums/internal/logic/memberservice/memberloginlogic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/feihua/zero-admin/pkg/pointerprocess"
 	"github.com/feihua/zero-admin/rpc/ums/gen/model"
 	"github.com/feihua/zero-admin/rpc/ums/gen/query"
 	"github.com/feihua/zero-admin/rpc/ums/internal/svc"
@@ -55,7 +56,7 @@ func (l *MemberLoginLogic) MemberLogin(in *umsclient.MemberLoginReq) (*umsclient
 		MemberID:   member.ID,
 		CreateTime: time.Now(),
 		MemberIP:   in.Ip,
-		City:       *member.City,
+		City:       pointerprocess.DefaltData(member.City).(string),
 		LoginType:  0,
 		Province:   "",
 	}

--- a/rpc/ums/internal/logic/memberservice/querymemberlistlogic.go
+++ b/rpc/ums/internal/logic/memberservice/querymemberlistlogic.go
@@ -2,8 +2,10 @@ package memberservicelogic
 
 import (
 	"context"
+	"github.com/feihua/zero-admin/pkg/pointerprocess"
 	"github.com/feihua/zero-admin/rpc/ums/gen/query"
 	"github.com/zeromicro/go-zero/core/logc"
+	"time"
 
 	"github.com/feihua/zero-admin/rpc/ums/internal/svc"
 	"github.com/feihua/zero-admin/rpc/ums/umsclient"
@@ -61,12 +63,12 @@ func (l *QueryMemberListLogic) QueryMemberList(in *umsclient.QueryMemberListReq)
 			Phone:                 member.Phone,
 			MemberStatus:          member.MemberStatus,
 			CreateTime:            member.CreateTime.Format("2006-01-02 15:04:05"),
-			Icon:                  *member.Icon,
-			Gender:                *member.Gender,
-			Birthday:              member.Birthday.Format("2006-01-02 15:04:05"),
-			City:                  *member.City,
-			Job:                   *member.Job,
-			PersonalizedSignature: *member.PersonalizedSignature,
+			Icon:                  pointerprocess.DefaltData(member.Icon).(string),
+			Gender:                pointerprocess.DefaltData(member.Gender).(int32),
+			Birthday:              pointerprocess.DefaltData(member.Birthday).(time.Time).Format("2006-01-02 15:04:05"),
+			City:                  pointerprocess.DefaltData(member.City).(string),
+			Job:                   pointerprocess.DefaltData(member.Job).(string),
+			PersonalizedSignature: pointerprocess.DefaltData(member.PersonalizedSignature).(string),
 			SourceType:            member.SourceType,
 			Integration:           member.Integration,
 			Growth:                member.Growth,


### PR DESCRIPTION
对于注册请求的新用户来说，登出后无法重新登录，原因是会员表city字段为空，登录业务里插入一条登录日志会出错，从而登陆失败。同样的，对于admin管理员查看会员列表存在同样问题，当查询的结果存在field为null时指针解应用会panic。

- 原因:对 nil 指针解引用会导致运行时 panic

- 处理:对于要解引用的指针先判断是否为nil做相应的处理
